### PR TITLE
Fix bug mapping data to the wrong region in Mexico.

### DIFF
--- a/src/pipelines/epidemiology/mx_authority.py
+++ b/src/pipelines/epidemiology/mx_authority.py
@@ -24,7 +24,7 @@ _SUBREGION1_CODE_MAP = {
     "02": "BCN",
     "03": "BCS",
     "04": "CAM",
-    "05": "COL",
+    "05": "COA",
     "06": "COL",
     "07": "CHP",
     "08": "CHH",


### PR DESCRIPTION
Currently both "05" and "06" are mapped to Colima.

Following the data description "05" should be Coahuila, which as per the index, has a key "COA".

http://epidemiologia.salud.gob.mx/gobmx/salud/datos_abiertos/diccionario_datos_covid19.zip / Catalogos_0412